### PR TITLE
Updated lib/ops.py to new location of the SON class.

### DIFF
--- a/lib/ops.py
+++ b/lib/ops.py
@@ -1,5 +1,5 @@
 from pymongo.errors import AutoReconnect
-from pymongo.son import SON
+from bson.son import SON
 
 
 class MongoOps():


### PR DESCRIPTION
Hey I had a problem with getting mtop to work on Python 2.7.3 with Pymongo 2.2.

I changed one line to point to the updated SON class.

Thanks for a great little script!
