### PR TITLE
fix where operation is executed by mongodb itself (eg: replication ops)

### DIFF
--- a/lib/runner.py
+++ b/lib/runner.py
@@ -139,7 +139,8 @@ class Runner:
         for op in inprog[:opsmax]:
             a = 'T' if op['active'] else 'F'
             lock = op.get('lockType') if op['waitingForLock'] else ''
-            self._print([template % (op['opid'], op['client'], op['op'], a, lock, op['ns'])])
+            client = op.get('client', 'internal')
+            self._print([template % (op['opid'], client, op['op'], a, lock, op['ns'])])
 
         if len(inprog) > opsmax:
             self._print(['( ... %d more ... )' % (len(inprog) - opsmax)])


### PR DESCRIPTION
when an operation is executed by mongodb itself (eg: replication ops) there is no 'client' field.
